### PR TITLE
Added an auth solution for websockets

### DIFF
--- a/env.dist
+++ b/env.dist
@@ -38,3 +38,8 @@ export FORCE_SSL=false
 # Which provider module will you use with Filer?
 # NOTE: You must include this provider in package.json or manually require it.
 export FILER_PROVIDER="filer-fs"
+
+# Time-to-live for Websocket tokens
+# (Default to 60 seconds)
+export TOKEN_TIMEOUT_MS=60000
+

--- a/server/index.js
+++ b/server/index.js
@@ -58,7 +58,7 @@ function corsOptions ( req, res ) {
 }
 
 // Declare routes
-routes( app );
+routes( app, webmakerAuth );
 
 port = env.get( "PORT", 9090 );
 var server = http.createServer( app );

--- a/server/lib/sync.js
+++ b/server/lib/sync.js
@@ -316,7 +316,7 @@ Sync.prototype.messageHandler = function( data ) {
   return this.socket.send(JSON.stringify(Sync.socket.errors.ETYPHN));
 };
 
-Sync.prototype.addSocket = function( ws ) {
+Sync.prototype.setSocket = function( ws ) {
   this.socket = ws;
   this.socketState = Sync.WSCON;
 };

--- a/server/lib/syncmessage.js
+++ b/server/lib/syncmessage.js
@@ -38,6 +38,18 @@ SyncMessage.prototype.setContent = function(content) {
   this.content = content;
 };
 
+SyncMessage.generateError = function(errorContent) {
+  var errorMsg = new SyncMessage(SyncMessage.RESPONSE, SyncMessage.ERROR);
+  errorMsg.setContent(errorContent.toString() || errorContent);
+
+  return errorMsg;
+};
+
+// Pre-baked instances
+SyncMessage.Response = {
+  ACK: new SyncMessage(SyncMessage.RESPONSE, SyncMessage.ACK)
+};
+
 // TODO: Expose a .toJSON method
 
 module.exports = SyncMessage;

--- a/server/lib/websocket-auth.js
+++ b/server/lib/websocket-auth.js
@@ -1,0 +1,91 @@
+var uuid = require('node-uuid');
+var env = require('./environment');
+
+/**
+ * This module creates and tracks session objects representing
+ * an analogue to sessions authenticated with Webmaker-Auth.
+ * Each session object can have secure tokens generated for it
+ * to be used to prove a user's identity when opening a
+ * websocket connection for a particular session.
+ *
+ * createSessionTracker(username)
+ *   - Creates an array to store tokens for a particular
+ *     user session, and returns the UUID representing it.
+ *
+ * generateTokenForSession(username, sessionId)
+ *   - Creates and stores a one-time use token for the passed user.
+ *     A user can have multiple tokens at a time, one for each
+ *     client session. After a set amount of time, the token expires
+ *     and can no longer be used.
+ *
+ * authorizeToken(token)
+ *   - If the token passed exists for a particular user, the token
+ *     is deleted from the datastore, returning true.
+ *
+ * purgeSession(username, sessionId)
+ *   - Deletes all tokens for a particular user session, intended to be
+ *     used on webmakerauth signout.
+ */
+var authTable = {};
+var TOKEN_TIMEOUT_MS = env.get("TOKEN_TIMEOUT_MS") || 60000; // Default to 60 sec
+
+function createSessionTracker() {
+  var sessionId = uuid.v4();
+  authTable[sessionId] = [];
+  return sessionId;
+}
+
+function generateTokenForSession(sessionId) {
+  var sessionData = authTable[sessionId];
+  var token = uuid.v4();
+
+  // Invalidate the token if the client doesn't
+  // use it in time.
+  setTimeout(function(){
+    if (authTable[sessionId]){
+      sessionData.splice(sessionData.indexOf(token), 1);
+    }
+  }, TOKEN_TIMEOUT_MS);
+
+  sessionData.push(token);
+  return token;
+}
+
+function authorizeToken(token) {
+  var sessionId,
+      username,
+      i;
+
+  for (sessionId in authTable) {
+    session = authTable[sessionId];
+
+    for (i = 0; i < session.length; i++) {
+      if (session[i] === token) {
+        session.splice(i, 1);
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function purgeSession(sessionId) {
+  var sessionData = authTable[sessionId];
+
+  if (sessionData) {
+    delete authTable[sessionId];
+  }
+}
+
+function logoutHandler(req, res, next) {
+  purgeSession(req.params.sessionId);
+  next();
+}
+
+module.exports = {
+  createSessionTracker: createSessionTracker,
+  generateTokenForSession: generateTokenForSession,
+  authorizeToken: authorizeToken,
+  purgeSession: purgeSession,
+  logoutHandler: logoutHandler
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -7,13 +7,22 @@ var middleware = require( './middleware' ),
     ws = require('ws'),
     SyncMessage = require('../lib/syncmessage'),
     WebSocket = require('ws'),
-    WebSocketServer = WebSocket.Server;
+    WebSocketServer = WebSocket.Server,
+    websocketAuth = require('../lib/websocket-auth');
 
 // TODO: Factor route groupings into their own files,
 //       build a system to require them here
-module.exports = function createRoutes( app, wss ) {
+module.exports = function createRoutes( app, webmakerAuth  ) {
+  // Client-side Webmaker Auth support
+  app.post('/verify', webmakerAuth.handlers.verify);
+  app.post('/authenticate', webmakerAuth.handlers.authenticate);
+  app.post('/logout', middleware.authenticationHandler, websocketAuth.logoutHandler, webmakerAuth.handlers.logout);
+  app.post('/create', webmakerAuth.handlers.create);
+  app.post('/check-username', webmakerAuth.handlers.exists);
+
   app.get( "/", routes.index );
   app.get( "/p/*", middleware.authenticationHandler, routes.servePath );
+  app.get( "/api/sync", middleware.authenticationHandler, routes.generateToken );
 
   /**
    * [SSE Socket]

--- a/server/routes/middleware/index.js
+++ b/server/routes/middleware/index.js
@@ -1,4 +1,5 @@
 var Sync = require('../../lib/sync');
+var websocketAuth = require('../../lib/websocket-auth');
 
 function generateError( code, msg ) {
   var err = new Error( msg );
@@ -13,7 +14,12 @@ module.exports = {
       return next( generateError( 401, "Webmaker Authentication Required." ) );
     }
 
+    if ( !req.session.sessionId ) {
+      req.session.sessionId = websocketAuth.createSessionTracker();
+    }
+
     req.params.username = username;
+    req.params.sessionId = req.session.sessionId;
     next();
   },
   crossOriginHandler: function( req, res, next ) {

--- a/server/routes/routes/index.js
+++ b/server/routes/routes/index.js
@@ -1,6 +1,7 @@
 var env = require('../../lib/environment'),
     version = require('../../../package.json').version,
-    FilerWebServer = require('../../lib/filer-www.js');
+    FilerWebServer = require('../../lib/filer-www.js'),
+    websocketAuth = require('../../lib/websocket-auth');
 
 module.exports = {
   // TODO: Factor this object into separate files as needed
@@ -20,5 +21,8 @@ module.exports = {
       http: "okay",
       version: version
     });
+  },
+  generateToken: function( req, res ) {
+    res.json(200, websocketAuth.generateTokenForSession(req.params.sessionId));
   }
 };

--- a/tests/unit/routes.js
+++ b/tests/unit/routes.js
@@ -13,142 +13,171 @@ beforeEach(function(){
   };
 })
 
-describe('/api/sync route', function () {
-  it('should return a 200 status code after trying to access the /api/sync route', function (done){
-    util.authenticatedConnection({done: done}, function(err, result) {
-      expect(err).not.to.exist;
-      request.get({
-        url: util.serverURL + '/api/sync/' + result.syncId,
-        jar: result.jar
-      }, function(err, res, body) {
+describe('[Route tests]', function() {
+  describe('/api/sync/:syncId route', function () {
+    it('should return a 200 status code after trying to access the /api/sync route', function (done){
+      util.authenticatedConnection({done: done}, function(err, result) {
         expect(err).not.to.exist;
-        expect(res.statusCode).to.equal(200);
-        result.done();
-      });
-    });
-  });
-  it('should return a 423 status code when trying to initiate more than 1 sync simultaneously with the same user logged in', function (done){
-    util.authenticatedConnection({done: done}, function(err, result1) {
-      expect(err).not.to.exist;
-      util.syncRouteConnect(result1, function(err, result2){
-        expect(err).not.to.exist;
-        util.syncRouteConnect(result2, function(err, result3){
+        request.get({
+          url: util.serverURL + '/api/sync/' + result.syncId,
+          jar: result.jar
+        }, function(err, res, body) {
           expect(err).not.to.exist;
-          expect(result2.statusCode).to.equal(423);
-          result3.done();
-        })
+          expect(res.statusCode).to.equal(200);
+          result.done();
+        });
       });
     });
-  });
-  it('should return a 400 status code when finding a mismatching syncId attached to the current user', function (done){
-    util.authenticatedConnection({done: done}, function(err, result1) {
-      expect(err).not.to.exist;
-      result1.syncId = uuid.v4();
-      util.syncRouteConnect(result1, function(err, result2){
+    it('should return a 423 status code when trying to initiate more than 1 sync simultaneously with the same user logged in', function (done){
+      util.authenticatedConnection({done: done}, function(err, result1) {
         expect(err).not.to.exist;
-        expect(result2.statusCode).to.equal(400);
-        result2.done();
+        util.syncRouteConnect(result1, function(err, result2){
+          expect(err).not.to.exist;
+          util.syncRouteConnect(result2, function(err, result3){
+            expect(err).not.to.exist;
+            expect(result2.statusCode).to.equal(423);
+            result3.done();
+          })
+        });
+      });
+    });
+    it('should return a 400 status code when finding a mismatching syncId attached to the current user', function (done){
+      util.authenticatedConnection({done: done}, function(err, result1) {
+        expect(err).not.to.exist;
+        result1.syncId = uuid.v4();
+        util.syncRouteConnect(result1, function(err, result2){
+          expect(err).not.to.exist;
+          expect(result2.statusCode).to.equal(400);
+          result2.done();
+        });
       });
     });
   });
-  // Can we test against sync.start's fatal mkdir error/500 statusCode?
-});
 
-describe('/api/sync/:syncId/sources route', function () {
-  it('should return a 400 status code if request.body is empty', function (done){
-    util.authenticatedConnection({done: done}, function(err, result1) {
-      expect(err).not.to.exist;
-        util.syncRouteConnect(result1, function(err, result2) {
-          expect(err).not.to.exist;
-          var localData = data;
-          localData.json = {};
-          util.sourceRouteConnect(result2, localData, function(err, result3) {
+  describe('/api/sync/:syncId/sources route', function () {
+    it('should return a 400 status code if request.body is empty', function (done){
+      util.authenticatedConnection({done: done}, function(err, result1) {
+        expect(err).not.to.exist;
+          util.syncRouteConnect(result1, function(err, result2) {
             expect(err).not.to.exist;
-            expect(result3.statusCode).to.equal(400);
-            result3.done();
-          });
+            var localData = data;
+            localData.json = {};
+            util.sourceRouteConnect(result2, localData, function(err, result3) {
+              expect(err).not.to.exist;
+              expect(result3.statusCode).to.equal(400);
+              result3.done();
+            });
+        });
+      });
+    });
+    it('should return a 400 when path is missing from request.body', function (done){
+      util.authenticatedConnection({done: done}, function(err, result1) {
+        expect(err).not.to.exist;
+          util.syncRouteConnect(result1, function(err, result2) {
+            expect(err).not.to.exist;
+            var localData = data;
+            delete localData.json.path;
+            util.sourceRouteConnect(result2, localData, function(err, result3) {
+              expect(err).not.to.exist;
+              expect(result3.statusCode).to.equal(400);
+              result3.done();
+            });
+        });
+      });
+    });
+    it('should return a 400 when the srcList is missing from request.body', function (done){
+      util.authenticatedConnection({done: done}, function(err, result1) {
+        expect(err).not.to.exist;
+          util.syncRouteConnect(result1, function(err, result2) {
+            expect(err).not.to.exist;
+            var localData = data;
+            delete localData.json.srcList;
+            util.sourceRouteConnect(result2, localData, function(err, result3) {
+              expect(err).not.to.exist;
+              expect(result3.statusCode).to.equal(400);
+              result3.done();
+            });
+        });
+      });
+    });
+    it('should return a 201 when sync successfully retrieves path and srcList', function (done){
+      util.authenticatedConnection({done: done}, function(err, result1) {
+        expect(err).not.to.exist;
+          util.syncRouteConnect(result1, function(err, result2) {
+            expect(err).not.to.exist;
+            util.sourceRouteConnect(result2, data, function(err, result3) {
+              expect(err).not.to.exist;
+              expect(result3.statusCode).to.equal(201);
+              result3.done();
+            });
+        });
       });
     });
   });
-  it('should return a 400 when path is missing from request.body', function (done){
-    util.authenticatedConnection({done: done}, function(err, result1) {
-      expect(err).not.to.exist;
-        util.syncRouteConnect(result1, function(err, result2) {
-          expect(err).not.to.exist;
-          var localData = data;
-          localData.json.path = undefined;
-          util.sourceRouteConnect(result2, localData, function(err, result3) {
-            expect(err).not.to.exist;
-            expect(result3.statusCode).to.equal(400);
-            result3.done();
-          });
-      });
-    });
-  });
-  it('should return a 400 when the srcList is missing from request.body', function (done){
-    util.authenticatedConnection({done: done}, function(err, result1) {
-      expect(err).not.to.exist;
-        util.syncRouteConnect(result1, function(err, result2) {
-          expect(err).not.to.exist;
-          var localData = data;
-          localData.json.srcList = undefined;
-          util.sourceRouteConnect(result2, localData, function(err, result3) {
-            expect(err).not.to.exist;
-            expect(result3.statusCode).to.equal(400);
-            result3.done();
-          });
-      });
-    });
-  });
-  it('should return a 201 when sync successfully retrieves path and srcList', function (done){
-    util.authenticatedConnection({done: done}, function(err, result1) {
-      expect(err).not.to.exist;
+
+  describe('/api/sync/:syncId/checksums', function () {
+    it('should return a 200 status code and the checksums after the sync validates', function (done){
+      util.authenticatedConnection({done: done}, function(err, result1) {
+        expect(err).not.to.exist;
         util.syncRouteConnect(result1, function(err, result2) {
           expect(err).not.to.exist;
           util.sourceRouteConnect(result2, data, function(err, result3) {
             expect(err).not.to.exist;
-            expect(result3.statusCode).to.equal(201);
-            result3.done();
-          });
-      });
-    });
-  });
-});
-
-describe('/api/sync/:syncId/checksums', function () {
-  it('should return a 200 status code and the checksums after the sync validates', function (done){
-    util.authenticatedConnection({done: done}, function(err, result1) {
-      expect(err).not.to.exist;
-      util.syncRouteConnect(result1, function(err, result2) {
-        expect(err).not.to.exist;
-        util.sourceRouteConnect(result2, data, function(err, result3) {
-          expect(err).not.to.exist;
-          util.csRouteConnect(result3, function(err, result4) {
-            expect(err).not.to.exist;
-            expect(result4.body.checksums.length).to.be.above(0);
-            expect(result4.statusCode).to.equal(200);
-            result4.done();
+            util.csRouteConnect(result3, function(err, result4) {
+              expect(err).not.to.exist;
+              expect(result4.body.checksums.length).to.be.above(0);
+              expect(result4.statusCode).to.equal(200);
+              result4.done();
+            });
           });
         });
       });
     });
   });
-});
 
-describe('/healthcheck', function () {
-  it('should return a 200 status code, an okay message, and the version if the healthcheck clears', function (done){
-    util.authenticatedConnection({done: done}, function(err, result) {
-      expect(err).not.to.exist;
-      request.get({
-        url: util.serverURL + '/healthcheck',
-        jar: result.jar,
-        json: true
-      }, function(err, res, body) {
+  describe('/healthcheck', function () {
+    it('should return a 200 status code, an okay message, and the version if the healthcheck clears', function (done){
+      util.authenticatedConnection({done: done}, function(err, result) {
         expect(err).not.to.exist;
-        expect(res.body.http).to.deep.equal('okay');
-        expect(res.body.version).to.exist;
-        expect(res.statusCode).to.equal(200);
-        result.done();
+        request.get({
+          url: util.serverURL + '/healthcheck',
+          jar: result.jar,
+          json: true
+        }, function(err, res, body) {
+          expect(err).not.to.exist;
+          expect(res.body.http).to.equal('okay');
+          expect(res.body.version).to.exist;
+          expect(res.statusCode).to.equal(200);
+          result.done();
+        });
+      });
+    });
+  });
+
+  describe('/api/sync', function() {
+    it('should return a token when a user is authenticated', function(done) {
+      util.authenticate({ username: util.username() }, function(err, authResult) {
+        request({
+          url: util.serverURL + '/api/sync',
+          jar: authResult.jar,
+          json: true
+        }, function(err, response, body) {
+          expect(err).not.to.exist;
+          expect(response.statusCode).to.equal(200);
+          expect(body).to.be.a('string');
+
+          done();
+        });
+      });
+    });
+    it('should reject a request with a 401 if the user is not authenticated', function(done) {
+      request({
+        url: util.serverURL + '/api/sync',
+        json: true
+      }, function(err, response, body) {
+        expect(response.statusCode).to.equal(401);
+
+        done();
       });
     });
   });


### PR DESCRIPTION
Until we figure out how to intercept the HTTP get request that is upgraded into a websocket, we will be using a token-based system to indicate that a websocket can be trusted. Anyone can open a websocket with the server with this approach, but only authenticated users will be able to get a token allowing them to use it.
